### PR TITLE
Update combat indicator dynamically

### DIFF
--- a/KrioUI/Main.lua
+++ b/KrioUI/Main.lua
@@ -2,8 +2,15 @@
 local _, ans = ...;
 local isFrameExist = ans.isFrameExist;
 local krioUiFrameName = "KrioUiMainFrame";
+local pveInstances = {"scenario", "party", "raid"};
 rG,gG,bG,aG = 1,1,1,1;
 
+local function arrayContainsItem(array, item)
+    for key, value in pairs(array) do
+        if value == item then return true end
+    end
+    return false
+end
 
 if  (not isFrameExist(krio)) then
     local frame = CreateFrame("Frame", krioUiFrameName);
@@ -13,6 +20,8 @@ if  (not isFrameExist(krio)) then
         --Tracking when player log into the world (logging in, /reload-ing)
         if (event == "PLAYER_ENTERING_WORLD" or event) then
             local initialLogin, reloadingUI = ...;
+            local inInstance, instanceType = IsInInstance();
+            ans.setPlayerIsInPVEInstance(arrayContainsItem(pveInstances, instanceType));
             if (initialLogin or reloadingUI) then
 
                 -- Load class colors
@@ -26,7 +35,7 @@ if  (not isFrameExist(krio)) then
                 end
                 if (prestigeIcons == true) then
                     ans.removePrestigeIcons();
-                end
+                                end
                 if (outlineNameplates == true) then
                     ans.outlineOnNamePlates();
                 end
@@ -96,7 +105,7 @@ hooksecurefunc("PlayerFrame_UpdateStatus", function(self)
     local combatStatusTexture = PlayerFrame.PlayerFrameContent.PlayerFrameContentMain.StatusTexture;
     local playerFrameTargetContextual = PlayerFrame_GetPlayerFrameContentContextual();
     local playerPortraitCornerIcon = playerFrameTargetContextual.PlayerPortraitCornerIcon;
-	local attackIcon = playerFrameTargetContextual.AttackIcon;
+    local attackIcon = playerFrameTargetContextual.AttackIcon;
     if (PlayerFrame.inCombat and redFlashInCombat == true) then
         combatStatusTexture:Hide();
     end

--- a/KrioUI/Settings.lua
+++ b/KrioUI/Settings.lua
@@ -348,39 +348,60 @@ local function outlineOnNamePlates()
     SetFont(SystemFont_NamePlateFixed,11) 
 end
 
+local function combatIndicatorYPosition_byPrestige() 
+    return prestigeIcons and 0 or 15
+end
+
 local function combatIndicator()
     if combatIndicator then
-		local targetFrame = CreateFrame("Frame", nil , TargetFrame)
-		targetFrame:SetPoint("LEFT", TargetFrame, "RIGHT", -20, 5)
-		targetFrame:SetSize(26,26)
-		targetFrame.icon = targetFrame:CreateTexture(nil, "BORDER")
-		targetFrame.icon:SetAllPoints()
-		targetFrame.icon:SetTexture([[Interface\Icons\ABILITY_DUALWIELD]])
-		targetFrame:Hide()
+        local function combatIndicatorXPosition_byUnitClassification(unitClassification)
+            local x = -20
+           
+            -- If unit is a elite
+            local uC = UnitClassification(unitClassification)
+            if ( uC == "elite" or uC == "rareelite" or uC == "rare" ) then
+                x = -13
+            end
 
-		local focusFrame = CreateFrame("Frame", nil , FocusFrame)
-		focusFrame:SetPoint("LEFT", FocusFrame, "RIGHT", -20, 5)
-		focusFrame:SetSize(26,26)
-		focusFrame.icon = focusFrame:CreateTexture(nil, "BORDER")
-		focusFrame.icon:SetAllPoints()
-		focusFrame.icon:SetTexture([[Interface\Icons\ABILITY_DUALWIELD]])
-		focusFrame:Hide()
+            return x
+        end
 
-		local UnitAffectingCombat = UnitAffectingCombat
+        local targetFrame = CreateFrame("Frame", nil , TargetFrame)
+        targetFrame:SetPoint("LEFT", TargetFrame, "RIGHT", combatIndicatorXPosition_byUnitClassification("target"), combatIndicatorYPosition_byPrestige() + 1)
+        targetFrame:SetSize(26,26)
+        targetFrame.icon = targetFrame:CreateTexture(nil, "BORDER")
+        targetFrame.icon:SetAllPoints()
+        targetFrame.icon:SetTexture([[Interface\Icons\ABILITY_DUALWIELD]])
+        targetFrame:Hide()
 
-		local function CombatIndicator_Update()
-			targetFrame:SetShown(UnitAffectingCombat("target"))
-			focusFrame:SetShown(UnitAffectingCombat("focus"))
-		end
+        local focusFrame = CreateFrame("Frame", nil , FocusFrame)
+        focusFrame:SetPoint("LEFT", FocusFrame, "RIGHT", combatIndicatorXPosition_byUnitClassification("focus"), combatIndicatorYPosition_byPrestige())
+        focusFrame:SetSize(26,26)
+        focusFrame.icon = focusFrame:CreateTexture(nil, "BORDER")
+        focusFrame.icon:SetAllPoints()
+        focusFrame.icon:SetTexture([[Interface\Icons\ABILITY_DUALWIELD]])
+        focusFrame:Hide()
 
-		C_Timer.NewTicker(0.1, CombatIndicator_Update)
-	end
+        local UnitAffectingCombat = UnitAffectingCombat
+
+        local function CombatIndicators_Update()
+            -- target
+            targetFrame:SetPoint("LEFT", TargetFrame, "RIGHT", combatIndicatorXPosition_byUnitClassification("target"), combatIndicatorYPosition_byPrestige() + 1)
+            targetFrame:SetShown(UnitAffectingCombat("target"))
+            -- focus
+            focusFrame:SetPoint("LEFT", FocusFrame, "RIGHT", combatIndicatorXPosition_byUnitClassification("focus"), combatIndicatorYPosition_byPrestige())
+            focusFrame:SetShown(UnitAffectingCombat("focus"))
+        end
+
+        C_Timer.NewTicker(0.01, CombatIndicators_Update)
+    end
 end
 
 local function combatIndicatorPlayer() 
     if combatIndicatorPlayer then
         local playerFrame = CreateFrame("Frame", nil , PlayerFrame)
-        playerFrame:SetPoint("LEFT", PlayerFrame, "LEFT", -10, 0)
+     
+        playerFrame:SetPoint("LEFT", PlayerFrame, "LEFT", -10, combatIndicatorYPosition_byPrestige())
         playerFrame:SetSize(26,26)
         playerFrame.icon = playerFrame:CreateTexture(nil, "BORDER")
         playerFrame.icon:SetAllPoints()
@@ -391,9 +412,9 @@ local function combatIndicatorPlayer()
 
         local function CombatIndicator_Update()
             playerFrame:SetShown(UnitAffectingCombat("player"))
-		end
+        end
 
-		C_Timer.NewTicker(0.1, CombatIndicator_Update)
+        C_Timer.NewTicker(0.01, CombatIndicator_Update)
     end
 end
 

--- a/KrioUI/Settings.lua
+++ b/KrioUI/Settings.lua
@@ -21,6 +21,9 @@ combatIndicatorPlayer = false;
 classIconPortrait = false;
 hideQuestTracker = false;
 
+-- Player state
+isInPVEInstance = false
+
 local function Setings_Load()
     if  (not ans.isFrameExist(krioUiPanelName)) then
         
@@ -133,131 +136,83 @@ local function Setings_Load()
             classColorCheckBox:SetPoint("TOPRIGHT", 0, -45)
             classColorCheckBox:SetChecked(classColors)
             classColorCheckBox:HookScript("OnClick", function()
-                if classColors == true then
-                    classColors = false
-                else
-                    classColors = true
-                end
+                classColors = not classColors
             end)
 
             local nameplateOutline = CreateFrame("CheckButton", nil, settingsFrame, "UICheckButtonTemplate")
             nameplateOutline:SetPoint("TOPRIGHT", 0, -85)
             nameplateOutline:SetChecked(outlineNameplates)
             nameplateOutline:HookScript("OnClick", function()
-                if outlineNameplates == true then
-                    outlineNameplates = false
-                else
-                    outlineNameplates = true
-                end
+                outlineNameplates = not outlineNameplates
             end)
 
             local combatIndicatorCheckbox = CreateFrame("CheckButton", nil, settingsFrame, "UICheckButtonTemplate")
             combatIndicatorCheckbox:SetPoint("TOPRIGHT", 0, -125)
             combatIndicatorCheckbox:SetChecked(combatIndicator)
             combatIndicatorCheckbox:HookScript("OnClick", function()
-                if combatIndicator == true then
-                    combatIndicator = false
-                else
-                    combatIndicator = true
-                end
+                combatIndicator = not combatIndicator
             end)
 
             local combatIndicatorPlayerCheckbox = CreateFrame("CheckButton", nil, settingsFrame, "UICheckButtonTemplate")
             combatIndicatorPlayerCheckbox:SetPoint("TOPRIGHT", 0, -165)
             combatIndicatorPlayerCheckbox:SetChecked(combatIndicatorPlayer)
             combatIndicatorPlayerCheckbox:HookScript("OnClick", function()
-                if combatIndicatorPlayer == true then
-                    combatIndicatorPlayer = false
-                else
-                    combatIndicatorPlayer = true
-                end
+                combatIndicatorPlayer = not combatIndicatorPlayer
             end)
 
             local classIconsPortraitCheckbox = CreateFrame("CheckButton", nil, settingsFrame, "UICheckButtonTemplate")
             classIconsPortraitCheckbox:SetPoint("TOPRIGHT", 0, -205)
             classIconsPortraitCheckbox:SetChecked(classIconPortrait)
             classIconsPortraitCheckbox:HookScript("OnClick", function()
-                if classIconPortrait == true then
-                    classIconPortrait = false
-                else
-                    classIconPortrait = true
-                end
+                classIconPortrait = not classIconPortrait
             end)
 
             local nameBackgroundColorCheckbox = CreateFrame("CheckButton", nil, settingsFrame, "UICheckButtonTemplate")
             nameBackgroundColorCheckbox:SetPoint("TOPRIGHT", 0, -245)
             nameBackgroundColorCheckbox:SetChecked(nameBackgroundColor)
             nameBackgroundColorCheckbox:HookScript("OnClick", function()
-                if nameBackgroundColor == true then
-                    nameBackgroundColor = false
-                else
-                    nameBackgroundColor = true
-                end
+                nameBackgroundColor = not nameBackgroundColor
             end)
 
             local prestigeIconsCheckbox = CreateFrame("CheckButton", nil, settingsFrame, "UICheckButtonTemplate")
             prestigeIconsCheckbox:SetPoint("TOPRIGHT", 0, -285)
             prestigeIconsCheckbox:SetChecked(prestigeIcons)
             prestigeIconsCheckbox:HookScript("OnClick", function()
-                if prestigeIcons == true then
-                    prestigeIcons = false
-                else
-                    prestigeIcons = true
-                end
+                prestigeIcons = not prestigeIcons
             end)
 
             local restedGlowEffectCheckbox = CreateFrame("CheckButton", nil, settingsFrame, "UICheckButtonTemplate")
             restedGlowEffectCheckbox:SetPoint("TOPRIGHT", 0, -325)
             restedGlowEffectCheckbox:SetChecked(restedGlowFX)
             restedGlowEffectCheckbox:HookScript("OnClick", function()
-                if restedGlowFX == true then
-                    restedGlowFX = false
-                else
-                    restedGlowFX = true
-                end
+                restedGlowFX = not restedGlowFX
             end)
 
             local restedZZZEffectCheckbox = CreateFrame("CheckButton", nil, settingsFrame, "UICheckButtonTemplate")
             restedZZZEffectCheckbox:SetPoint("TOPRIGHT", 0, -365)
             restedZZZEffectCheckbox:SetChecked(restedZZZFx)
             restedZZZEffectCheckbox:HookScript("OnClick", function()
-                if restedZZZFx == true then
-                    restedZZZFx = false
-                else
-                    restedZZZFx = true
-                end
+                restedZZZFx = not restedZZZFx
             end)
 
             local portraitCornerIconCheckbox = CreateFrame("CheckButton", nil, settingsFrame, "UICheckButtonTemplate")
             portraitCornerIconCheckbox:SetPoint("TOPRIGHT", 0, -405)
             portraitCornerIconCheckbox:SetChecked(cornerIcon)
             portraitCornerIconCheckbox:HookScript("OnClick", function()
-                if cornerIcon == true then
-                    cornerIcon = false
-                else
-                    cornerIcon = true
-                end
+                cornerIcon = not cornerIcon
             end)
 
             local redFlashInCombatCheckbox = CreateFrame("CheckButton", nil, settingsFrame, "UICheckButtonTemplate")
             redFlashInCombatCheckbox:SetPoint("TOPRIGHT", 0, -445)
             redFlashInCombatCheckbox:SetChecked(redFlashInCombat)
             redFlashInCombatCheckbox:HookScript("OnClick", function()
-                if redFlashInCombat == true then
-                    redFlashInCombat = false
-                else
-                    redFlashInCombat = true
-                end
+                redFlashInCombat = not redFlashInCombat
             end)
             local hideQuestTrackerInBGCheckbox = CreateFrame("CheckButton", nil, settingsFrame, "UICheckButtonTemplate")
             hideQuestTrackerInBGCheckbox:SetPoint("TOPRIGHT", 0, -485)
             hideQuestTrackerInBGCheckbox:SetChecked(hideQuestTracker)
             hideQuestTrackerInBGCheckbox:HookScript("OnClick", function()
-                if hideQuestTracker == true then
-                    hideQuestTracker = false
-                else
-                    hideQuestTracker = true
-                end
+                hideQuestTracker = not hideQuestTracker
             end)
 
             local frameColorButton = CreateFrame("Button", nil, settingsFrame, "UIPanelButtonTemplate")
@@ -349,7 +304,11 @@ local function outlineOnNamePlates()
 end
 
 -- return different x coordination in case prestige icons are turned on/off 
-local function combatIndicatorYPosition_byPrestige() 
+local function combatIndicatorYPosition_byPrestigeAndInstanceFlag() 
+    if (isInPVEInstance) then
+        return 0
+    end
+
     return prestigeIcons and 0 or 15
 end
 
@@ -386,10 +345,11 @@ local function combatIndicator()
 
         local function CombatIndicators_Update()
             -- show combat indicator in case target is in combat
-            targetFrame:SetPoint("LEFT", TargetFrame, "RIGHT", combatIndicatorXPosition_byUnitClassification("target"), combatIndicatorYPosition_byPrestige() + 1)
+            -- plus one correction as it seems like the target is indicator of center
+            targetFrame:SetPoint("LEFT", TargetFrame, "RIGHT", combatIndicatorXPosition_byUnitClassification("target"), combatIndicatorYPosition_byPrestigeAndInstanceFlag() + 1)
             targetFrame:SetShown(UnitAffectingCombat("target"))
             -- show combat indicator in case focus is in combat
-            focusFrame:SetPoint("LEFT", FocusFrame, "RIGHT", combatIndicatorXPosition_byUnitClassification("focus"), combatIndicatorYPosition_byPrestige())
+            focusFrame:SetPoint("LEFT", FocusFrame, "RIGHT", combatIndicatorXPosition_byUnitClassification("focus"), combatIndicatorYPosition_byPrestigeAndInstanceFlag())
             focusFrame:SetShown(UnitAffectingCombat("focus"))
         end
         -- update timer to check if unit frame is in combat
@@ -401,7 +361,6 @@ local function combatIndicatorPlayer()
     if combatIndicatorPlayer then
         local playerFrame = CreateFrame("Frame", nil , PlayerFrame)
      
-        playerFrame:SetPoint("LEFT", PlayerFrame, "LEFT", -10, combatIndicatorYPosition_byPrestige())
         playerFrame:SetSize(26,26)
         playerFrame.icon = playerFrame:CreateTexture(nil, "BORDER")
         playerFrame.icon:SetAllPoints()
@@ -409,6 +368,7 @@ local function combatIndicatorPlayer()
         playerFrame:Hide()
 
         local function CombatIndicator_Update()
+            playerFrame:SetPoint("LEFT", PlayerFrame, "LEFT", -10, combatIndicatorYPosition_byPrestigeAndInstanceFlag())
             playerFrame:SetShown(UnitAffectingCombat("player"))
         end
 
@@ -430,6 +390,10 @@ function ShowColorPicker(r, g, b)
     ColorPickerFrame:Show();
 end
 
+function setPlayerIsInPVEInstance(pveInstance) 
+    isInPVEInstance = pveInstance
+end
+
 ans.removeRestedGlowEffect = removeRestedGlowEffect;
 ans.combatIndicator = combatIndicator;
 ans.outlineOnNamePlates = outlineOnNamePlates;
@@ -438,3 +402,4 @@ ans.nameBackgroundColor = nameBackgroundColor;
 ans.Setings_Load = Setings_Load;
 ans.cornerIcon = cornerIcon;
 ans.combatIndicatorPlayer = combatIndicatorPlayer;
+ans.setPlayerIsInPVEInstance = setPlayerIsInPVEInstance

--- a/KrioUI/Settings.lua
+++ b/KrioUI/Settings.lua
@@ -370,7 +370,6 @@ local function combatIndicator()
 
         -- Attach combat icon to target frame and hide by default
         local targetFrame = CreateFrame("Frame", nil , TargetFrame)
-        targetFrame:SetPoint("LEFT", TargetFrame, "RIGHT", combatIndicatorXPosition_byUnitClassification("target"), combatIndicatorYPosition_byPrestige() + 1)
         targetFrame:SetSize(26,26)
         targetFrame.icon = targetFrame:CreateTexture(nil, "BORDER")
         targetFrame.icon:SetAllPoints()
@@ -379,7 +378,6 @@ local function combatIndicator()
 
         -- Attach combat icon to focus frame and hide by default
         local focusFrame = CreateFrame("Frame", nil , FocusFrame)
-        focusFrame:SetPoint("LEFT", FocusFrame, "RIGHT", combatIndicatorXPosition_byUnitClassification("focus"), combatIndicatorYPosition_byPrestige())
         focusFrame:SetSize(26,26)
         focusFrame.icon = focusFrame:CreateTexture(nil, "BORDER")
         focusFrame.icon:SetAllPoints()

--- a/KrioUI/Settings.lua
+++ b/KrioUI/Settings.lua
@@ -348,16 +348,18 @@ local function outlineOnNamePlates()
     SetFont(SystemFont_NamePlateFixed,11) 
 end
 
+-- return different x coordination in case prestige icons are turned on/off 
 local function combatIndicatorYPosition_byPrestige() 
     return prestigeIcons and 0 or 15
 end
 
 local function combatIndicator()
     if combatIndicator then
+        -- return different x coordination in case unit is rare/elite/rareelite
         local function combatIndicatorXPosition_byUnitClassification(unitClassification)
             local x = -20
            
-            -- If unit is a elite
+            -- Blizz function to retrieve unit type
             local uC = UnitClassification(unitClassification)
             if ( uC == "elite" or uC == "rareelite" or uC == "rare" ) then
                 x = -13
@@ -366,6 +368,7 @@ local function combatIndicator()
             return x
         end
 
+        -- Attach combat icon to target frame and hide by default
         local targetFrame = CreateFrame("Frame", nil , TargetFrame)
         targetFrame:SetPoint("LEFT", TargetFrame, "RIGHT", combatIndicatorXPosition_byUnitClassification("target"), combatIndicatorYPosition_byPrestige() + 1)
         targetFrame:SetSize(26,26)
@@ -374,6 +377,7 @@ local function combatIndicator()
         targetFrame.icon:SetTexture([[Interface\Icons\ABILITY_DUALWIELD]])
         targetFrame:Hide()
 
+        -- Attach combat icon to focus frame and hide by default
         local focusFrame = CreateFrame("Frame", nil , FocusFrame)
         focusFrame:SetPoint("LEFT", FocusFrame, "RIGHT", combatIndicatorXPosition_byUnitClassification("focus"), combatIndicatorYPosition_byPrestige())
         focusFrame:SetSize(26,26)
@@ -385,14 +389,14 @@ local function combatIndicator()
         local UnitAffectingCombat = UnitAffectingCombat
 
         local function CombatIndicators_Update()
-            -- target
+            -- show combat indicator in case target is in combat
             targetFrame:SetPoint("LEFT", TargetFrame, "RIGHT", combatIndicatorXPosition_byUnitClassification("target"), combatIndicatorYPosition_byPrestige() + 1)
             targetFrame:SetShown(UnitAffectingCombat("target"))
-            -- focus
+            -- show combat indicator in case focus is in combat
             focusFrame:SetPoint("LEFT", FocusFrame, "RIGHT", combatIndicatorXPosition_byUnitClassification("focus"), combatIndicatorYPosition_byPrestige())
             focusFrame:SetShown(UnitAffectingCombat("focus"))
         end
-
+        -- update timer to check if unit frame is in combat
         C_Timer.NewTicker(0.01, CombatIndicators_Update)
     end
 end

--- a/KrioUI/Settings.lua
+++ b/KrioUI/Settings.lua
@@ -408,8 +408,6 @@ local function combatIndicatorPlayer()
         playerFrame.icon:SetTexture([[Interface\Icons\ABILITY_DUALWIELD]])
         playerFrame:Hide()
 
-        local UnitAffectingCombat = UnitAffectingCombat
-
         local function CombatIndicator_Update()
             playerFrame:SetShown(UnitAffectingCombat("player"))
         end

--- a/KrioUI/Settings.lua
+++ b/KrioUI/Settings.lua
@@ -386,8 +386,6 @@ local function combatIndicator()
         focusFrame.icon:SetTexture([[Interface\Icons\ABILITY_DUALWIELD]])
         focusFrame:Hide()
 
-        local UnitAffectingCombat = UnitAffectingCombat
-
         local function CombatIndicators_Update()
             -- show combat indicator in case target is in combat
             targetFrame:SetPoint("LEFT", TargetFrame, "RIGHT", combatIndicatorXPosition_byUnitClassification("target"), combatIndicatorYPosition_byPrestige() + 1)


### PR DESCRIPTION
Combat indicator now switch positions based on settings. 

Now will move to center position when player is in PvE instance (no prestige icon is visible).